### PR TITLE
docs: bootstrap do zero — corrigir pré-requisitos do README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Este repositório faz parte de um conjunto de 5 repos:
 | Linguagem    | TypeScript 5.x           |
 | Navegação    | React Navigation         |
 | HTTP Client  | Axios                    |
-| Autenticação | Auth0 (OAuth 2.0)        |
+| Autenticação | JWT próprio (HS256)      |
 | Notificações | Firebase Cloud Messaging |
 | i18n         | i18next (pt-BR / en-US)  |
 
@@ -37,6 +37,7 @@ Este repositório faz parte de um conjunto de 5 repos:
 - npm >= 10
 - Expo Go (no celular) ou emulador Android/iOS
 - Backend (petcard-api) rodando em http://localhost:3000
+- GitHub Personal Access Token com escopo `read:packages` (para baixar `@petcardorg/shared` do GitHub Packages)
 
 ## Instalação
 
@@ -45,14 +46,18 @@ Este repositório faz parte de um conjunto de 5 repos:
 git clone https://github.com/PetCardOrg/petcard-mobile.git
 cd petcard-mobile
 
-# 2. Instale as dependências
+# 2. Autentique no GitHub Packages (necessário para @petcardorg/shared)
+# Crie um token em https://github.com/settings/tokens com escopo read:packages
+export NODE_AUTH_TOKEN=<seu_personal_access_token>
+
+# 3. Instale as dependências
 npm install
 
-# 3. Configure as variáveis de ambiente
+# 4. Configure as variáveis de ambiente
 cp .env.example .env
-# Edite o .env com a URL da API e credenciais Auth0
+# Ajuste EXPO_PUBLIC_API_URL se a API não estiver em http://localhost:3000
 
-# 4. Inicie o Expo
+# 5. Inicie o Expo
 npm start
 # Escaneie o QR Code com o Expo Go ou pressione 'a' para Android / 'i' para iOS
 ```
@@ -68,7 +73,7 @@ npm start
 
 ## Funcionalidades
 
-- Cadastro e login do tutor via Auth0
+- Cadastro e login do tutor via JWT próprio
 - Gerenciamento de pets (CRUD)
 - Registro de vacinas, vermifugações e medicações
 - Carteira digital de saúde com QR Code


### PR DESCRIPTION
## Contexto

Dia 3 do plano de ação da auditoria (bootstrap do zero confiável). Endereça o Risco de Apresentação #2 ("setup do zero falha") na parte do **petcard-mobile**.

## Mudanças (README)

- **Auth0 removido** (3 menções: tabela de stack, comentário do `.env`, funcionalidades) — Auth0 foi abandonado (M0-#7); autenticação é **JWT próprio (HS256)**
- adicionada a etapa de **`NODE_AUTH_TOKEN` (`read:packages`)** antes do `npm install` — o `.npmrc` consome `@petcardorg/shared` do GitHub Packages, então sem o token o `npm install` falha em máquina limpa
- comentário do `.env` corrigido (o `.env.example` real só tem `EXPO_PUBLIC_API_URL` e a chave do Maps; nunca teve credenciais Auth0)

Sem mudança de código — só documentação de setup.