### PR TITLE
chore: alinhar @petcardorg/shared em ^0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@expo/ngrok": "^4.1.3",
         "@expo/vector-icons": "^15.1.1",
-        "@petcardorg/shared": "^0.8.0",
+        "@petcardorg/shared": "^0.9.0",
         "@react-navigation/bottom-tabs": "^7.15.9",
         "@react-navigation/material-top-tabs": "^7.4.23",
         "@react-navigation/native": "^7.2.2",
@@ -3006,9 +3006,9 @@
       }
     },
     "node_modules/@petcardorg/shared": {
-      "version": "0.8.0",
-      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.8.0/233c89357be07e38b1d11c1dbb24cbcb37297ed9",
-      "integrity": "sha512-KRwfLYCOwwpzkbECM1opBcNEr/bYE4FA6xiPtAivNt53SpIIrvLkWwAlzKSd87R6V+2cCv9u2VGV2LCIfewMCw==",
+      "version": "0.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.9.0/3d77c7b90a05ab9f9058739a3ea70d94f807a2db",
+      "integrity": "sha512-Uz4vaqyOMw1LZ5guOHrJFxoXXDYAlcQCJndbgHpCL3pjYBDszi3vYl3PMlo1UPfnRkdURY5pFZymUh74GwLAhg==",
       "license": "MIT",
       "peerDependencies": {
         "class-transformer": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@expo/ngrok": "^4.1.3",
     "@expo/vector-icons": "^15.1.1",
-    "@petcardorg/shared": "^0.8.0",
+    "@petcardorg/shared": "^0.9.0",
     "@react-navigation/bottom-tabs": "^7.15.9",
     "@react-navigation/material-top-tabs": "^7.4.23",
     "@react-navigation/native": "^7.2.2",


### PR DESCRIPTION
## Contexto
Dia 4 da auditoria (Segurança e contratos), achado #6 (🟡).

Resolve o **skew de versão** do contrato compartilhado `@petcardorg/shared` e deixa de manter o release `0.9.0` órfão (publicado no M5, mas não consumido).

- api: `^0.8.0` → `^0.9.0`
- web: `^0.7.0` → `^0.9.0`
- mobile: `^0.8.0` → `^0.9.0`

`package-lock.json` atualizado junto. Os DTOs de M5 (veterinário/nota clínica) já estão no pacote; cópias locais no backend são **duplicação consciente** (nomenclatura própria do domínio, ex.: `CreateVetNoteDto`), documentada no DAS §5.2.

## Validação
- api: `tsc` ✅, `jest` 151/151 ✅
- web: `npm run build` ✅
- mobile: `tsc --noEmit` ✅